### PR TITLE
feat: refine babel-plugin-add-module-exports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,12 @@ module.exports = function(context, options) {
     ]);
   }
   if (typeof options.modules === 'undefined' || options.modules) {
-    preset.plugins.push(require('babel-plugin-add-module-exports'));
+    preset.plugins.push([
+      require('babel-plugin-add-module-exports'),
+      {
+        addDefaultProperty: true,
+      },
+    ]);
   }
 
   return preset;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "precommit": "npm run lint"
   },
   "dependencies": {
-    "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-add-module-exports": "^1.0.4",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-proto-to-assign": "^6.26.0",


### PR DESCRIPTION
以 `lib/config-provider/index.js` 为例，目前 babel 之后，打出来的代码类似于这样

```js
exports.default = (0, _reactLifecyclesCompat.polyfill)(ConfigProvider);
module.exports = exports['default'];
```

这样的代码，使用方只能 `const ConfigProvider = require('lib/config-provider/index.js')`，不能 `import ConfigProvider from 'lib/config-provider/index.js';`

升级 babel-plugin-add-module-exports 到 1.x 且配了 `addDefaultProperty: true` 之后打出来的代码是这样

```js
exports.default = (0, _reactLifecyclesCompat.polyfill)(ConfigProvider);
module.exports = exports.default;
module.exports.default = exports.default;
```

这样使用方既能 `require` 又能 `import` 了